### PR TITLE
Upgrade phoenix html and fix warning

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule ScrivenerHtml.Mixfile do
   defp deps do
     [
       {:scrivener, "~> 1.2 or ~> 2.0"},
-      {:phoenix_html, "~> 2.2 or ~> 3.0"},
+      {:phoenix_html, "~> 2.2 or ~> 3.0 or ~> 4.0"},
       {:phoenix, "~> 1.0", optional: true},
       {:plug, "~> 1.1"},
       {:ex_doc, "~> 0.19", only: :dev},


### PR DESCRIPTION
Allow using phoenix_html 4+ and fix warning in config file.

Unfortunately the main repo looks abandoned and we may need to think of using other library for pagination or create our own. https://github.com/mgwidmann/scrivener_html